### PR TITLE
Fix quality measure for scan WiFi on MacOS

### DIFF
--- a/src/mac-scan.js
+++ b/src/mac-scan.js
@@ -56,7 +56,7 @@ function parseAirport(terms, str) {
         )
       ),
       signal_level: lines[i].substr(colRssi, colChannel - colRssi).trim(),
-      quality: networkUtils.dBFromQuality(
+      quality: networkUtils.qualityFromDB(
         lines[i].substr(colRssi, colChannel - colRssi).trim()
       ),
       security: security,


### PR DESCRIPTION
## Description

Fixes quality measure for scanning WiFi networks on MacOS by changing from `dBFromQuality` to `qualityFromDB`.

## Motivation and Context

See (https://github.com/friedrith/node-wifi/issues/71)[https://github.com/friedrith/node-wifi/issues/71] for an overview of the issue.

## Usage examples

```js
import * as wifi from 'node-wifi';

wifi.scan();
```

## How Has This Been Tested?

Tested on macOS Catalina on a 2019 MacBook Pro.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
