### PR TITLE
Add timeout parameter under linux-connect

### DIFF
--- a/src/linux-connect.js
+++ b/src/linux-connect.js
@@ -4,7 +4,7 @@ var env = require('./env');
 function connectToWifi(config, ap, callback, timeout) {
   var args = [];
   args.push('-w');
-  args.push(timeout);
+  args.push(timeout || '10');
   args.push('device');
   args.push('wifi');
   args.push('connect');

--- a/src/linux-connect.js
+++ b/src/linux-connect.js
@@ -1,10 +1,10 @@
 var execFile = require('child_process').execFile;
 var env = require('./env');
 
-function connectToWifi(config, ap, callback) {
+function connectToWifi(config, ap, callback, timeout) {
   var args = [];
   args.push('-w');
-  args.push('10');
+  args.push(timeout);
   args.push('device');
   args.push('wifi');
   args.push('connect');
@@ -27,18 +27,23 @@ function connectToWifi(config, ap, callback) {
 }
 
 module.exports = function(config) {
-  return function(ap, callback) {
+  return function(ap, callback, timeout) {
     if (callback) {
-      connectToWifi(config, ap, callback);
+      connectToWifi(config, ap, callback, timeout);
     } else {
       return new Promise(function(resolve, reject) {
-        connectToWifi(config, ap, function(err) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        });
+        connectToWifi(
+          config,
+          ap,
+          function(err) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          },
+          timeout
+        );
       });
     }
   };


### PR DESCRIPTION
## Description

Changes the timeout parameter found in the `connectToWifi` function in the `linux-connect.js` from a static string of `10` (10 seconds) to a be based on an argument. Still defaults to 10 seconds however if no `timeout` argument is provided.

## Motivation and Context

This change is required to allow for slow connection times on low powered devices such as Raspberry Pi's.

## Usage examples

Example of connecting to a Wi-Fi network with a 60 second timeout:
`wifi.connect({ ssid: 'Test Network', password: 'Test Password' }, undefined, '60');`.

## How Has This Been Tested?

It has been tested on a number of Raspberry Pi's running Raspbian Buster and a 2019 MacBook Pro running macOS Catalina.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
